### PR TITLE
[DEVOPS-1833]: statsite now has gauge aggregates

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -52,6 +52,7 @@ objs = env_statsite_with_err.Object('src/hashmap', 'src/hashmap.c')           + 
         env_statsite_with_err.Object('src/cm_quantile', 'src/cm_quantile.c')  + \
         env_statsite_with_err.Object('src/timer', 'src/timer.c')              + \
         env_statsite_with_err.Object('src/counter', 'src/counter.c')          + \
+        env_statsite_with_err.Object('src/gauge', 'src/gauge.c')          + \
         env_statsite_with_err.Object('src/metrics', 'src/metrics.c')          + \
         env_statsite_with_err.Object('src/streaming', 'src/streaming.c')      + \
         env_statsite_with_err.Object('src/config', 'src/config.c')            + \

--- a/integ/test_binary_stream.py
+++ b/integ/test_binary_stream.py
@@ -252,17 +252,20 @@ class TestInteg(object):
         "Tests streaming gauges"
         server, _, output = servers
         server.sendall(format("g1", "g", 500))
+        server.sendall(format("g1", "g", 200))
+        server.sendall(format("g1", "g", 200))
+
         wait_file(output)
         now = time.time()
         out = open(output).read()
 
         # Adjust for time drift
-        if format_output(now - 1, "g1", BIN_TYPES["g"], VAL_TYPE_MAP["kv"], 500) in out:
+        if format_output(now - 1, "g1", BIN_TYPES["g"], VAL_TYPE_MAP["kv"], 200) in out:
             now = now - 1
 
-        assert format_output(now, "g1", BIN_TYPES["g"], VAL_TYPE_MAP["kv"], 500) in out
-        assert format_output(now, "g1", BIN_TYPES["g"], VAL_TYPE_MAP["sum"], 500) in out
-        assert format_output(now, "g1", BIN_TYPES["g"], VAL_TYPE_MAP["mean"], 500) in out
+        assert format_output(now, "g1", BIN_TYPES["g"], VAL_TYPE_MAP["kv"], 200) in out
+        assert format_output(now, "g1", BIN_TYPES["g"], VAL_TYPE_MAP["sum"], 900) in out
+        assert format_output(now, "g1", BIN_TYPES["g"], VAL_TYPE_MAP["mean"], 300) in out
 
 
     def test_counters(self, servers):
@@ -373,18 +376,20 @@ class TestIntegPrefix(object):
         "Tests streaming gauges"
         server, _, output = serversPrefix
         server.sendall(format("g1", "g", 500))
+        server.sendall(format("g1", "g", 100))
+        server.sendall(format("g1", "g", 300))
         wait_file(output)
         now = time.time()
         out = open(output).read()
 
 
         # Adjust for time drift
-        if format_output(now - 1, "g1", BIN_TYPES["g"], VAL_TYPE_MAP["kv"], 500) in out:
+        if format_output(now - 1, "g1", BIN_TYPES["g"], VAL_TYPE_MAP["kv"], 300) in out:
             now = now - 1
 
-        assert format_output(now, "gauges.g1", BIN_TYPES["g"], VAL_TYPE_MAP["kv"], 500) in out
-        assert format_output(now, "gauges.g1", BIN_TYPES["g"], VAL_TYPE_MAP["sum"], 500) in out
-        assert format_output(now, "gauges.g1", BIN_TYPES["g"], VAL_TYPE_MAP["mean"], 500) in out
+        assert format_output(now, "gauges.g1", BIN_TYPES["g"], VAL_TYPE_MAP["kv"], 300) in out
+        assert format_output(now, "gauges.g1", BIN_TYPES["g"], VAL_TYPE_MAP["sum"], 900) in out
+        assert format_output(now, "gauges.g1", BIN_TYPES["g"], VAL_TYPE_MAP["mean"], 300) in out
 
 
     def test_counters(self, serversPrefix):

--- a/integ/test_binary_stream.py
+++ b/integ/test_binary_stream.py
@@ -255,8 +255,15 @@ class TestInteg(object):
         wait_file(output)
         now = time.time()
         out = open(output).read()
-        assert out in (format_output(now, "g1", BIN_TYPES["g"], VAL_TYPE_MAP["kv"], 500),
-                       format_output(now - 1, "g1", BIN_TYPES["g"], VAL_TYPE_MAP["kv"], 500))
+
+        # Adjust for time drift
+        if format_output(now - 1, "g1", BIN_TYPES["g"], VAL_TYPE_MAP["kv"], 500) in out:
+            now = now - 1
+
+        assert format_output(now, "g1", BIN_TYPES["g"], VAL_TYPE_MAP["kv"], 500) in out
+        assert format_output(now, "g1", BIN_TYPES["g"], VAL_TYPE_MAP["sum"], 500) in out
+        assert format_output(now, "g1", BIN_TYPES["g"], VAL_TYPE_MAP["mean"], 500) in out
+
 
     def test_counters(self, servers):
         "Tests adding kv pairs"
@@ -369,8 +376,16 @@ class TestIntegPrefix(object):
         wait_file(output)
         now = time.time()
         out = open(output).read()
-        assert out in (format_output(now, "gauges.g1", BIN_TYPES["g"], VAL_TYPE_MAP["kv"], 500),
-                       format_output(now - 1, "gauges.g1", BIN_TYPES["g"], VAL_TYPE_MAP["kv"], 500))
+
+
+        # Adjust for time drift
+        if format_output(now - 1, "g1", BIN_TYPES["g"], VAL_TYPE_MAP["kv"], 500) in out:
+            now = now - 1
+
+        assert format_output(now, "gauges.g1", BIN_TYPES["g"], VAL_TYPE_MAP["kv"], 500) in out
+        assert format_output(now, "gauges.g1", BIN_TYPES["g"], VAL_TYPE_MAP["sum"], 500) in out
+        assert format_output(now, "gauges.g1", BIN_TYPES["g"], VAL_TYPE_MAP["mean"], 500) in out
+
 
     def test_counters(self, serversPrefix):
         "Tests adding kv pairs"

--- a/src/gauge.c
+++ b/src/gauge.c
@@ -1,0 +1,66 @@
+#include <math.h>
+#include "gauge.h"
+
+/**
+ * Initializes the gauge struct
+ * @arg gauge The gauge struct to initialize
+ * @return 0 on success.
+ */
+int init_gauge(gauge_t *gauge) {
+    counter->count = 0;
+    counter->sum = 0;
+    return 0;
+}
+
+/**
+ * Adds a new sample to the struct
+ * @arg gauge The gauge to add to
+ * @arg sample The new sample value
+ * @return 0 on success.
+ */
+int gauge_add_sample(gauge_t *gauge, double sample) {
+    if (gauge->count == 0) {
+        gauge->sum = sample;
+    }
+
+    gauge->value = sample;
+    gauge->count++;
+    gauge->sum += sample;
+    return 0;
+}
+
+/**
+ * Returns the number of samples in the gauge
+ * @arg gauge The gauge to query
+ * @return The number of samples
+ */
+uint64_t gauge_count(gauge_t *gauge) {
+    return gauge->count;
+}
+
+/**
+ * Returns the mean gauge value
+ * @arg gauge The gauge to query
+ * @return The mean value of the gauge
+ */
+double gauge_mean(gauge_t *gauge) {
+    return (gauge->count) ? gauge->sum / gauge->count : 0;
+}
+
+/**
+ * Returns the sum of the gauge
+ * @arg gauge The gauge to query
+ * @return The sum of values
+ */
+double gauge_sum(gauge_t *gauge) {
+    return gauge->sum;
+}
+
+/**
+ * Returns the gauge value (for backwards compat)
+ * @arg gauge  the gauge to query
+ * @return The gauge value
+ */
+double gauge_value(gauge_t *gauge) {
+    return gauge->value;
+}

--- a/src/gauge.c
+++ b/src/gauge.c
@@ -1,5 +1,4 @@
 #include <math.h>
-#include <stdbool.h>
 #include "gauge.h"
 
 /**

--- a/src/gauge.c
+++ b/src/gauge.c
@@ -23,11 +23,10 @@ int init_gauge(gauge_t *gauge) {
 int gauge_add_sample(gauge_t *gauge, double sample, bool delta) {
     if (delta) {
         gauge->value += sample;
-        gauge->sum += sample;
     } else {
         gauge->value = sample;
-        gauge->sum = sample;
     }
+    gauge->sum += sample;
     gauge->count++;
     return 0;
 }

--- a/src/gauge.c
+++ b/src/gauge.c
@@ -1,11 +1,7 @@
 #include <math.h>
 #include "gauge.h"
 
-/**
- * Initializes the gauge struct
- * @arg gauge The gauge struct to initialize
- * @return 0 on success.
- */
+
 int init_gauge(gauge_t *gauge) {
     gauge->count = 0;
     gauge->sum = 0;
@@ -13,13 +9,6 @@ int init_gauge(gauge_t *gauge) {
     return 0;
 }
 
-/**
- * Adds a new sample to the struct
- * @arg gauge The gauge to add to
- * @arg sample The new sample value
- * @arg delta   Is this a delta update?
- * @return 0 on success.
- */
 int gauge_add_sample(gauge_t *gauge, double sample, bool delta) {
     if (delta) {
         gauge->value += sample;
@@ -31,38 +20,18 @@ int gauge_add_sample(gauge_t *gauge, double sample, bool delta) {
     return 0;
 }
 
-/**
- * Returns the number of samples in the gauge
- * @arg gauge The gauge to query
- * @return The number of samples
- */
 uint64_t gauge_count(gauge_t *gauge) {
     return gauge->count;
 }
 
-/**
- * Returns the mean gauge value
- * @arg gauge The gauge to query
- * @return The mean value of the gauge
- */
 double gauge_mean(gauge_t *gauge) {
     return (gauge->count) ? gauge->sum / gauge->count : 0;
 }
 
-/**
- * Returns the sum of the gauge
- * @arg gauge The gauge to query
- * @return The sum of values
- */
 double gauge_sum(gauge_t *gauge) {
     return gauge->sum;
 }
 
-/**
- * Returns the gauge value (for backwards compat)
- * @arg gauge  the gauge to query
- * @return The gauge value
- */
 double gauge_value(gauge_t *gauge) {
     return gauge->value;
 }

--- a/src/gauge.c
+++ b/src/gauge.c
@@ -7,9 +7,9 @@
  * @return 0 on success.
  */
 int init_gauge(gauge_t *gauge) {
-    counter->count = 0;
-    counter->sum = 0;
-    counter->value = 0;
+    gauge->count = 0;
+    gauge->sum = 0;
+    gauge->value = 0;
     return 0;
 }
 

--- a/src/gauge.c
+++ b/src/gauge.c
@@ -9,6 +9,7 @@
 int init_gauge(gauge_t *gauge) {
     counter->count = 0;
     counter->sum = 0;
+    counter->value = 0;
     return 0;
 }
 
@@ -16,16 +17,22 @@ int init_gauge(gauge_t *gauge) {
  * Adds a new sample to the struct
  * @arg gauge The gauge to add to
  * @arg sample The new sample value
+ * @arg delta   Is this a delta update?
  * @return 0 on success.
  */
-int gauge_add_sample(gauge_t *gauge, double sample) {
+int gauge_add_sample(gauge_t *gauge, double sample, bool delta) {
     if (gauge->count == 0) {
         gauge->sum = sample;
     }
 
-    gauge->value = sample;
+    if (delta) {
+        gauge->value += sample;
+        gauge->sum += sample;
+    } else {
+        gauge->value = sample;
+        gauge->sum = sample;
+    }
     gauge->count++;
-    gauge->sum += sample;
     return 0;
 }
 

--- a/src/gauge.c
+++ b/src/gauge.c
@@ -21,10 +21,6 @@ int init_gauge(gauge_t *gauge) {
  * @return 0 on success.
  */
 int gauge_add_sample(gauge_t *gauge, double sample, bool delta) {
-    if (gauge->count == 0) {
-        gauge->sum = sample;
-    }
-
     if (delta) {
         gauge->value += sample;
         gauge->sum += sample;

--- a/src/gauge.c
+++ b/src/gauge.c
@@ -1,4 +1,5 @@
 #include <math.h>
+#include <stdbool.h>
 #include "gauge.h"
 
 /**

--- a/src/gauge.h
+++ b/src/gauge.h
@@ -30,7 +30,7 @@ int gauge_add_sample(gauge_t *gauge, double sample, bool delta);
  * @arg gauge The gauge to query
  * @return The number of samples
  */
-uint64_t gauge_count(gauge_t *counter);
+uint64_t gauge_count(gauge_t *gauge);
 
 /**
  * Returns the mean gauge value

--- a/src/gauge.h
+++ b/src/gauge.h
@@ -1,0 +1,56 @@
+#ifndef GAUGE_H
+#define GAUGE_H
+#include <stdint.h>
+
+typedef struct {
+    uint64_t count;     // Count of items
+    double sum;         // Sum of the values
+    double value;       // redundant if count == 1, keeping it to reduce footprint of changes
+} gauge_t;
+
+
+/**
+ * Initializes the gauge struct
+ * @arg gauge The gauge struct to initialize
+ * @return 0 on success.
+ */
+int init_gauge(gauge_t *gauge);
+
+/**
+ * Adds a new sample to the struct
+ * @arg gauge The gauge to add to
+ * @arg sample The new sample value
+ * @return 0 on success.
+ */
+int gauge_add_sample(gauge_t *gauge, double sample);
+
+/**
+ * Returns the number of samples in the gauge
+ * @arg gauge The gauge to query
+ * @return The number of samples
+ */
+uint64_t gauge_count(gauge_t *counter);
+
+/**
+ * Returns the mean gauge value
+ * @arg gauge The gauge to query
+ * @return The mean value
+ */
+double gauge_mean(gauge_t *gauge);
+
+/**
+ * Returns the sum of the gauge
+ * @arg gauge The gauge to query
+ * @return The sum of values
+ */
+double gauge_sum(gauge_t *gauge);
+
+
+/**
+ * Returns the gauge value (for backwards compat)
+ * @arg gauge  the gauge to query
+ * @return The gauge value
+ */
+double gauge_value(gauge_t *gauge);
+
+#endif

--- a/src/gauge.h
+++ b/src/gauge.h
@@ -1,6 +1,7 @@
 #ifndef GAUGE_H
 #define GAUGE_H
 #include <stdint.h>
+#include <stdbool.h>
 
 typedef struct {
     uint64_t count;     // Count of items

--- a/src/gauge.h
+++ b/src/gauge.h
@@ -20,9 +20,10 @@ int init_gauge(gauge_t *gauge);
  * Adds a new sample to the struct
  * @arg gauge The gauge to add to
  * @arg sample The new sample value
+ * @arg delta   Is this a delta update?
  * @return 0 on success.
  */
-int gauge_add_sample(gauge_t *gauge, double sample);
+int gauge_add_sample(gauge_t *gauge, double sample, bool delta);
 
 /**
  * Returns the number of samples in the gauge

--- a/src/metrics.c
+++ b/src/metrics.c
@@ -194,9 +194,7 @@ static int metrics_set_gauge(metrics *m, char *name, double val, bool delta) {
     // New gauge
     if (res == -1) {
         g = malloc(sizeof(gauge_t));
-        g->value = 0;
-        g->sum = 0;
-        g->count = 0;
+        init_gauge(g);
         hashmap_put(m->gauges, name, g);
     }
 

--- a/src/metrics.c
+++ b/src/metrics.c
@@ -181,7 +181,7 @@ static int metrics_add_kv(metrics *m, char *name, double val) {
 }
 
 /**
- * Sets a guage value
+ * Sets a gauge value
  * @arg name The name of the gauge
  * @arg val The value to set
  * @arg delta Is this a delta update
@@ -195,15 +195,12 @@ static int metrics_set_gauge(metrics *m, char *name, double val, bool delta) {
     if (res == -1) {
         g = malloc(sizeof(gauge_t));
         g->value = 0;
+        g->sum = 0;
+        g->count = 0;
         hashmap_put(m->gauges, name, g);
     }
 
-    if (delta) {
-        g->value += val;
-    } else {
-        g->value = val;
-    }
-    return 0;
+    return gauge_add_sample(c, val, delta);
 }
 
 /**

--- a/src/metrics.c
+++ b/src/metrics.c
@@ -200,7 +200,7 @@ static int metrics_set_gauge(metrics *m, char *name, double val, bool delta) {
         hashmap_put(m->gauges, name, g);
     }
 
-    return gauge_add_sample(c, val, delta);
+    return gauge_add_sample(g, val, delta);
 }
 
 /**

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -5,6 +5,7 @@
 #include "radix.h"
 #include "counter.h"
 #include "timer.h"
+#include "gauge.h"
 #include "hashmap.h"
 #include "set.h"
 
@@ -21,10 +22,6 @@ typedef struct {
     histogram_config *conf;
     unsigned int *counts;
 } timer_hist;
-
-typedef struct {
-    double value;
-} gauge_t;
 
 typedef struct {
     hashmap *counters;  // Hashmap of name -> counter structs

--- a/src/sink_stream.c
+++ b/src/sink_stream.c
@@ -69,6 +69,8 @@ static int stream_formatter_bin(FILE *pipe, void *data, metric_type type, char *
 
         case GAUGE:
             STREAM_BIN(BIN_TYPE_GAUGE, BIN_OUT_NO_TYPE, ((gauge_t*)value)->value);
+            STREAM_BIN(BIN_TYPE_GAUGE, BIN_OUT_SUM, gauge_sum(value));
+            STREAM_BIN(BIN_TYPE_GAUGE, BIN_OUT_MEAN, gauge_mean(value));
             break;
 
         case COUNTER:

--- a/tests/runner.c
+++ b/tests/runner.c
@@ -6,6 +6,7 @@
 #include "test_heap.c"
 #include "test_timer.c"
 #include "test_counter.c"
+#include "test_gauge.c"
 #include "test_metrics.c"
 #include "test_streaming.c"
 #include "test_config.c"
@@ -25,14 +26,15 @@ int main(void)
     TCase *tc3 = tcase_create("heap");
     TCase *tc4 = tcase_create("timer");
     TCase *tc5 = tcase_create("counter");
-    TCase *tc6 = tcase_create("metrics");
-    TCase *tc7 = tcase_create("streaming");
-    TCase *tc8 = tcase_create("config");
-    TCase *tc9 = tcase_create("radix");
-    TCase *tc10 = tcase_create("hyperloglog");
-    TCase *tc11 = tcase_create("set");
-    TCase *tc12 = tcase_create("lifoq");
-    TCase *tc13 = tcase_create("strbuf");
+    TCase *tc6 = tcase_create("gauge");
+    TCase *tc7 = tcase_create("metrics");
+    TCase *tc8 = tcase_create("streaming");
+    TCase *tc9 = tcase_create("config");
+    TCase *tc10 = tcase_create("radix");
+    TCase *tc11 = tcase_create("hyperloglog");
+    TCase *tc12 = tcase_create("set");
+    TCase *tc13 = tcase_create("lifoq");
+    TCase *tc14 = tcase_create("strbuf");
     SRunner *sr = srunner_create(s1);
     int nf;
 
@@ -87,85 +89,91 @@ int main(void)
     tcase_add_test(tc5, test_counter_init_add);
     tcase_add_test(tc5, test_counter_add_loop);
 
-    // Add the counter tests
+    // Add the gauge tests
     suite_add_tcase(s1, tc6);
-    tcase_add_test(tc6, test_metrics_init_and_destroy);
-    tcase_add_test(tc6, test_metrics_init_defaults_and_destroy);
-    tcase_add_test(tc6, test_metrics_empty_iter);
-    tcase_add_test(tc6, test_metrics_add_iter);
-    tcase_add_test(tc6, test_metrics_add_all_iter);
-    tcase_add_test(tc6, test_metrics_histogram);
-    tcase_add_test(tc6, test_metrics_gauges);
+    tcase_add_test(tc6, test_counter_init);
+    tcase_add_test(tc6, test_counter_init_add);
+    tcase_add_test(tc6, test_counter_add_loop);
+
+    // Add the counter tests
+    suite_add_tcase(s1, tc7);
+    tcase_add_test(tc7, test_metrics_init_and_destroy);
+    tcase_add_test(tc7, test_metrics_init_defaults_and_destroy);
+    tcase_add_test(tc7, test_metrics_empty_iter);
+    tcase_add_test(tc7, test_metrics_add_iter);
+    tcase_add_test(tc7, test_metrics_add_all_iter);
+    tcase_add_test(tc7, test_metrics_histogram);
+    tcase_add_test(tc7, test_metrics_gauges);
 
     // Add the streaming tests
-    suite_add_tcase(s1, tc7);
-    tcase_add_test(tc7, test_stream_empty);
-    tcase_add_test(tc7, test_stream_some);
-    tcase_add_test(tc7, test_stream_bad_cmd);
-    tcase_add_test(tc7, test_stream_sigpipe);
+    suite_add_tcase(s1, tc8);
+    tcase_add_test(tc8, test_stream_empty);
+    tcase_add_test(tc8, test_stream_some);
+    tcase_add_test(tc8, test_stream_bad_cmd);
+    tcase_add_test(tc8, test_stream_sigpipe);
 
     // Add the config tests
-    suite_add_tcase(s1, tc8);
-    tcase_add_test(tc8, test_config_get_default);
-    tcase_add_test(tc8, test_config_bad_file);
-    tcase_add_test(tc8, test_config_empty_file);
-    tcase_add_test(tc8, test_config_basic_config);
-    tcase_add_test(tc8, test_validate_default_config);
-    tcase_add_test(tc8, test_validate_bad_config);
-    tcase_add_test(tc8, test_join_path_no_slash);
-    tcase_add_test(tc8, test_join_path_with_slash);
-    tcase_add_test(tc8, test_sane_log_level);
-    tcase_add_test(tc8, test_sane_log_facility);
-    tcase_add_test(tc8, test_sane_timer_eps);
-    tcase_add_test(tc8, test_sane_flush_interval);
-    tcase_add_test(tc8, test_sane_histograms);
-    tcase_add_test(tc8, test_sane_set_eps);
-    tcase_add_test(tc8, test_config_histograms);
-    tcase_add_test(tc8, test_build_radix);
-    tcase_add_test(tc8, test_sane_prefixes);
-    tcase_add_test(tc8, test_sane_global_prefix);
-    tcase_add_test(tc8, test_sane_quantiles);
-    tcase_add_test(tc8, test_basic_sink);
-    tcase_add_test(tc8, test_multi_sink);
+    suite_add_tcase(s1, tc9);
+    tcase_add_test(tc9, test_config_get_default);
+    tcase_add_test(tc9, test_config_bad_file);
+    tcase_add_test(tc9, test_config_empty_file);
+    tcase_add_test(tc9, test_config_basic_config);
+    tcase_add_test(tc9, test_validate_default_config);
+    tcase_add_test(tc9, test_validate_bad_config);
+    tcase_add_test(tc9, test_join_path_no_slash);
+    tcase_add_test(tc9, test_join_path_with_slash);
+    tcase_add_test(tc9, test_sane_log_level);
+    tcase_add_test(tc9, test_sane_log_facility);
+    tcase_add_test(tc9, test_sane_timer_eps);
+    tcase_add_test(tc9, test_sane_flush_interval);
+    tcase_add_test(tc9, test_sane_histograms);
+    tcase_add_test(tc9, test_sane_set_eps);
+    tcase_add_test(tc9, test_config_histograms);
+    tcase_add_test(tc9, test_build_radix);
+    tcase_add_test(tc9, test_sane_prefixes);
+    tcase_add_test(tc9, test_sane_global_prefix);
+    tcase_add_test(tc9, test_sane_quantiles);
+    tcase_add_test(tc9, test_basic_sink);
+    tcase_add_test(tc9, test_multi_sink);
 
     // Add the radix tests
-    suite_add_tcase(s1, tc9);
-    tcase_add_test(tc9, test_radix_init_and_destroy);
-    tcase_add_test(tc9, test_radix_insert);
-    tcase_add_test(tc9, test_radix_search);
-    tcase_add_test(tc9, test_radix_longest_prefix);
-    tcase_add_test(tc9, test_radix_foreach);
+    suite_add_tcase(s1, tc10);
+    tcase_add_test(tc10, test_radix_init_and_destroy);
+    tcase_add_test(tc10, test_radix_insert);
+    tcase_add_test(tc10, test_radix_search);
+    tcase_add_test(tc10, test_radix_longest_prefix);
+    tcase_add_test(tc10, test_radix_foreach);
 
     // Add the hll tests
-    suite_add_tcase(s1, tc10);
-    tcase_add_test(tc10, test_hll_init_bad);
-    tcase_add_test(tc10, test_hll_init_and_destroy);
-    tcase_add_test(tc10, test_hll_add);
-    tcase_add_test(tc10, test_hll_add_hash);
-    tcase_add_test(tc10, test_hll_add_size);
-    tcase_add_test(tc10, test_hll_size);
-    tcase_add_test(tc10, test_hll_error_bound);
-    tcase_add_test(tc10, test_hll_precision_for_error);
+    suite_add_tcase(s1, tc11);
+    tcase_add_test(tc11, test_hll_init_bad);
+    tcase_add_test(tc11, test_hll_init_and_destroy);
+    tcase_add_test(tc11, test_hll_add);
+    tcase_add_test(tc11, test_hll_add_hash);
+    tcase_add_test(tc11, test_hll_add_size);
+    tcase_add_test(tc11, test_hll_size);
+    tcase_add_test(tc11, test_hll_error_bound);
+    tcase_add_test(tc11, test_hll_precision_for_error);
 
     // Add the set tests
-    suite_add_tcase(s1, tc11);
-    tcase_add_test(tc11, test_set_init_destroy);
-    tcase_add_test(tc11, test_set_add_size_exact);
-    tcase_add_test(tc11, test_set_add_size_exact_dedup);
-    tcase_add_test(tc11, test_set_error_bound);
+    suite_add_tcase(s1, tc12);
+    tcase_add_test(tc12, test_set_init_destroy);
+    tcase_add_test(tc12, test_set_add_size_exact);
+    tcase_add_test(tc12, test_set_add_size_exact_dedup);
+    tcase_add_test(tc12, test_set_error_bound);
 
     // Add the lifoq tests
-    suite_add_tcase(s1, tc12);
-    tcase_add_test(tc12, test_lifoq_make);
-    tcase_add_test(tc12, test_lifoq_basic);
-    tcase_add_test(tc12, test_lifoq_overflow);
-    tcase_add_test(tc12, test_lifoq_close);
+    suite_add_tcase(s1, tc13);
+    tcase_add_test(tc13, test_lifoq_make);
+    tcase_add_test(tc13, test_lifoq_basic);
+    tcase_add_test(tc13, test_lifoq_overflow);
+    tcase_add_test(tc13, test_lifoq_close);
 
     // Add the strbuf tests
-    suite_add_tcase(s1, tc13);
-    tcase_add_test(tc13, test_strbuf_new);
-    tcase_add_test(tc13, test_strbuf_printf);
-    tcase_add_test(tc13, test_strbuf_big);
+    suite_add_tcase(s1, tc14);
+    tcase_add_test(tc14, test_strbuf_new);
+    tcase_add_test(tc14, test_strbuf_printf);
+    tcase_add_test(tc14, test_strbuf_big);
 
 
     srunner_run_all(sr, CK_ENV);

--- a/tests/test_gauge.c
+++ b/tests/test_gauge.c
@@ -20,7 +20,7 @@ END_TEST
 START_TEST(test_gauge_init_add)
 {
     gauge_t g;
-    int res = inti_gauge(&g);
+    int res = init_gauge(&g);
     fail_unless(res == 0);
 
     fail_unless(gauge_add_sample(&g, 100) == 0);

--- a/tests/test_gauge.c
+++ b/tests/test_gauge.c
@@ -12,7 +12,7 @@
 START_TEST(test_gauge_init)
 {
     gauge_t g;
-    int res = init_gauge(&c);
+    int res = init_gauge(&g);
     fail_unless(res == 0);
 }
 END_TEST
@@ -23,11 +23,11 @@ START_TEST(test_gauge_init_add)
     int res = init_gauge(&g);
     fail_unless(res == 0);
 
-    fail_unless(gauge_add_sample(&g, 100) == 0);
+    fail_unless(gauge_add_sample(&g, 100, false) == 0);
     fail_unless(gauge_count(&g) == 1);
     fail_unless(gauge_sum(&g) == 100);
     fail_unless(gauge_value(&g) == 100);    
-    fail_unless(gauge_mean(&c) == 100);
+    fail_unless(gauge_mean(&g) == 100);
 }
 END_TEST
 
@@ -37,8 +37,9 @@ START_TEST(test_gauge_add_loop)
     int res = init_gauge(&g);
     fail_unless(res == 0);
 
-    for (int i=1; i<=100; i++)
-        fail_unless(gauge_add_sample(&g, i) == 0);
+    fail_unless(gauge_add_sample(&g, 1, false) == 0);
+    for (int i=2; i<=100; i++)
+        fail_unless(gauge_add_sample(&g, i, true) == 0);
 
     fail_unless(gauge_count(&g) == 100);
     fail_unless(gauge_sum(&g) == 5050);

--- a/tests/test_gauge.c
+++ b/tests/test_gauge.c
@@ -1,0 +1,49 @@
+#include <check.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <math.h>
+#include "gauge.h"
+
+START_TEST(test_gauge_init)
+{
+    gauge_t g;
+    int res = init_gauge(&c);
+    fail_unless(res == 0);
+}
+END_TEST
+
+START_TEST(test_gauge_init_add)
+{
+    gauge_t g;
+    int res = inti_gauge(&g);
+    fail_unless(res == 0);
+
+    fail_unless(gauge_add_sample(&g, 100) == 0);
+    fail_unless(gauge_count(&g) == 1);
+    fail_unless(gauge_sum(&g) == 100);
+    fail_unless(gauge_value(&g) == 100);    
+    fail_unless(gauge_mean(&c) == 100);
+}
+END_TEST
+
+START_TEST(test_gauge_add_loop)
+{
+    gauge_t g;
+    int res = init_gauge(&g);
+    fail_unless(res == 0);
+
+    for (int i=1; i<=100; i++)
+        fail_unless(gauge_add_sample(&g, i) == 0);
+
+    fail_unless(gauge_count(&g) == 100);
+    fail_unless(gauge_sum(&g) == 5050);
+    fail_unless(gauge_mean(&g) == 50.5);
+    fail_unless(gauge_value(&g) == 5050);
+}
+END_TEST
+


### PR DESCRIPTION
cc @theatrus 

```
root@statsd-development-iad-onebox:/srv/repos/statsite# make test
scons test_runner
scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
gcc -o src/gauge.o -c -Wall -Wno-unused-function -std=c99 -fno-strict-aliasing -fno-omit-frame-pointer -D_GNU_SOURCE -g3 -O3 -pthread -Ideps/inih -Ideps/libev -Isrc -Werror src/gauge.c
scons: `test_runner' is up to date.
scons: done building targets.
./test_runner
Running suite(s): Statsite
100%: Checks: 95, Failures: 0, Errors: 0

root@statsd-development-iad-onebox:/srv/repos/statsite# make test_integ
rootdir: /srv/repos/statsite/integ, inifile:
collected 65 items

platform linux2 -- Python 2.7.6, pytest-2.8.5, py-1.4.31, pluggy-0.3.1
rootdir: /srv/repos/statsite/integ, inifile:
collected 65 items

integ/test_binary.py ..............
integ/test_binary_stream.py ............
integ/test_extended_counters.py ..
integ/test_integ.py .........................
integ/test_librato.py ...
integ/test_stdin.py .........

```

