### PR TITLE
Reset sample_rate on each loop

### DIFF
--- a/src/conn_handler.c
+++ b/src/conn_handler.c
@@ -179,8 +179,10 @@ static int handle_ascii_client_connect(statsite_conn_handler *handle) {
     int buf_len, should_free, status, i, after_len;
     double val;
     double sample_rate = 1.0;
-    
+
     while (1) {
+        sample_rate = 1.0;
+
         status = extract_to_terminator(handle->conn, '\n', &buf, &buf_len, &should_free);
         if (status == -1) return 0; // Return if no command is available
 


### PR DESCRIPTION
/cc @yashlyft 

If multiple inbound lines were received, sample_rate may not have been reset on each line to 1.0, leading to odd .count values