### PR TITLE
Fix failing test subunits

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -70,7 +70,7 @@ if platform.system() == 'Linux':
    statsite_libs.append("rt")
 
 statsite = env_statsite_with_err.Program('statsite', objs + ["src/statsite.c"], LIBS=statsite_libs)
-statsite_test = env_statsite_without_err.Program('test_runner', objs + Glob("tests/runner.c"), LIBS=statsite_libs + ["check"])
+statsite_test = env_statsite_without_err.Program('test_runner', objs + Glob("tests/runner.c"), LIBS=statsite_libs + ["check", "subunit"])
 
 # By default, only compile statsite
 Default(statsite)


### PR DESCRIPTION
* include the check subunit linker flag

before this change `make test` results in the following.
```/usr/lib/gcc/x86_64-linux-gnu/6/../../../x86_64-linux-gnu/libcheck.a(check_log.o): In function `subunit_lfun':
(.text+0x5f4): undefined reference to `subunit_test_start'
/usr/lib/gcc/x86_64-linux-gnu/6/../../../x86_64-linux-gnu/libcheck.a(check_log.o): In function `subunit_lfun':
(.text+0x6bf): undefined reference to `subunit_test_fail'
/usr/lib/gcc/x86_64-linux-gnu/6/../../../x86_64-linux-gnu/libcheck.a(check_log.o): In function `subunit_lfun':
(.text+0x6d4): undefined reference to `subunit_test_pass'
/usr/lib/gcc/x86_64-linux-gnu/6/../../../x86_64-linux-gnu/libcheck.a(check_log.o): In function `subunit_lfun':
(.text+0x6ef): undefined reference to `subunit_test_error'
collect2: error: ld returned 1 exit status
scons: *** [test_runner] Error 1
scons: building terminated because of errors.
Makefile:20: recipe for target 'test' failed
make: *** [test] Error 2```

