### PR TITLE
direct gauges: Support unaggregated gauges

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -42,29 +42,30 @@ env_statsite_with_err = ENV.Clone(CFLAGS = " ".join(CFLAGS_ERROR))
 env_statsite_without_err = ENV.Clone(CFLAGS = " ".join(CFLAGS))
 env_statsite_libev = ENV.Clone(CFLAGS = " ".join(CFLAGS_LIBEV))
 
-objs = env_statsite_with_err.Object('src/hashmap', 'src/hashmap.c')           + \
-        env_statsite_with_err.Object('src/heap', 'src/heap.c')                + \
-        env_statsite_with_err.Object('src/strbuf', 'src/strbuf.c')            + \
-        env_statsite_with_err.Object('src/radix', 'src/radix.c')              + \
-        env_statsite_with_err.Object('src/hll_constants', 'src/hll_constants.c') + \
-        env_statsite_with_err.Object('src/hll', 'src/hll.c')                  + \
-        env_statsite_with_err.Object('src/set', 'src/set.c')                  + \
-        env_statsite_with_err.Object('src/cm_quantile', 'src/cm_quantile.c')  + \
-        env_statsite_with_err.Object('src/timer', 'src/timer.c')              + \
-        env_statsite_with_err.Object('src/counter', 'src/counter.c')          + \
-        env_statsite_with_err.Object('src/gauge', 'src/gauge.c')          + \
-        env_statsite_with_err.Object('src/metrics', 'src/metrics.c')          + \
-        env_statsite_with_err.Object('src/streaming', 'src/streaming.c')      + \
-        env_statsite_with_err.Object('src/config', 'src/config.c')            + \
-        env_statsite_with_err.Object('src/circqueue', 'src/circqueue.c')      + \
-        env_statsite_with_err.Object('src/sink', 'src/sink.c')                + \
-        env_statsite_with_err.Object('src/sink_stream', 'src/sink_stream.c')  + \
-        env_statsite_with_err.Object('src/lifoq', 'src/lifoq.c')              + \
-        env_statsite_with_err.Object('src/sink_http', 'src/sink_http.c')      + \
-        env_statsite_with_err.Object('src/utils', 'src/utils.c')              + \
-        env_statsite_with_err.Object('src/elide', 'src/elide.c')              + \
-        env_statsite_with_err.Object('src/rand', 'src/rand.c')                + \
-        env_statsite_libev.Object('src/networking', 'src/networking.c')       + \
+objs = env_statsite_with_err.Object('src/hashmap', 'src/hashmap.c')                  + \
+        env_statsite_with_err.Object('src/heap', 'src/heap.c')                       + \
+        env_statsite_with_err.Object('src/strbuf', 'src/strbuf.c')                   + \
+        env_statsite_with_err.Object('src/radix', 'src/radix.c')                     + \
+        env_statsite_with_err.Object('src/hll_constants', 'src/hll_constants.c')     + \
+        env_statsite_with_err.Object('src/hll', 'src/hll.c')                         + \
+        env_statsite_with_err.Object('src/set', 'src/set.c')                         + \
+        env_statsite_with_err.Object('src/cm_quantile', 'src/cm_quantile.c')         + \
+        env_statsite_with_err.Object('src/timer', 'src/timer.c')                     + \
+        env_statsite_with_err.Object('src/counter', 'src/counter.c')                 + \
+        env_statsite_with_err.Object('src/gauge', 'src/gauge.c')                     + \
+        env_statsite_with_err.Object('src/gauge_direct', 'src/gauge_direct.c')       + \
+        env_statsite_with_err.Object('src/metrics', 'src/metrics.c')                 + \
+        env_statsite_with_err.Object('src/streaming', 'src/streaming.c')             + \
+        env_statsite_with_err.Object('src/config', 'src/config.c')                   + \
+        env_statsite_with_err.Object('src/circqueue', 'src/circqueue.c')             + \
+        env_statsite_with_err.Object('src/sink', 'src/sink.c')                       + \
+        env_statsite_with_err.Object('src/sink_stream', 'src/sink_stream.c')         + \
+        env_statsite_with_err.Object('src/lifoq', 'src/lifoq.c')                     + \
+        env_statsite_with_err.Object('src/sink_http', 'src/sink_http.c')             + \
+        env_statsite_with_err.Object('src/utils', 'src/utils.c')                     + \
+        env_statsite_with_err.Object('src/elide', 'src/elide.c')                     + \
+        env_statsite_with_err.Object('src/rand', 'src/rand.c')                       + \
+        env_statsite_libev.Object('src/networking', 'src/networking.c')              + \
         env_statsite_libev.Object('src/conn_handler', 'src/conn_handler.c')
 
 statsite_libs = ["m", "pthread", murmur, inih, "jansson", curl_lib]

--- a/src/config.c
+++ b/src/config.c
@@ -60,7 +60,7 @@ static const statsite_config DEFAULT_CONFIG = {
     12,                 // Set precision 12, 1.6% variance
     true,               // Use type prefixes by default
     "",                 // Global prefix
-    {"", "kv.", "gauges.", "counts.", "timers.", "sets.", ""},
+    {"", "gauges.", "counts.", "timers.", "sets.", "", "gauges."},
     {},
     false,              // Extended counts off by default
     sizeof(default_quantiles) / sizeof(double),
@@ -508,8 +508,8 @@ static int config_callback(void* user, const char* section, const char* name, co
         config->prefixes[TIMER] = strdup(value);
     } else if (NAME_MATCH("sets_prefix")) {
         config->prefixes[SET] = strdup(value);
-    } else if (NAME_MATCH("kv_prefix")) {
-        config->prefixes[KEY_VAL] = strdup(value);
+    } else if (NAME_MATCH("gaugesdirect_prefix")) {
+        config->prefixes[GAUGE_DIRECT] = strdup(value);
 
     // Copy the multi-case variables
     } else if (NAME_MATCH("log_facility")) {
@@ -519,6 +519,7 @@ static int config_callback(void* user, const char* section, const char* name, co
     } else {
         // Log it, but ignore
         syslog(LOG_NOTICE, "Unrecognized config parameter: %s", name);
+        return 0;
     }
 
     // Success
@@ -808,10 +809,6 @@ void free_config(statsite_config* config) {
     if (config->pid_file != NULL) {
         free(config->pid_file);
     }
-    if (config->prefixes[COUNTER] != NULL) {
-        free(config->prefixes[COUNTER]);
-    }
-
     for (int i = 0; i < METRIC_TYPES; i++) {
         if (config->prefixes_final[i] != NULL) {
             free(config->prefixes_final[i]);

--- a/src/config.h
+++ b/src/config.h
@@ -7,12 +7,12 @@
 
 typedef enum {
     UNKNOWN,
-    KEY_VAL,
     GAUGE,
     COUNTER,
     TIMER,
     SET,
-    GAUGE_DELTA
+    GAUGE_DELTA,
+    GAUGE_DIRECT, /* Like a gauge, but zero other aggregation support */
 } metric_type;
 
 typedef enum {

--- a/src/conn_handler.c
+++ b/src/conn_handler.c
@@ -191,8 +191,9 @@ static int handle_ascii_client_connect(statsite_conn_handler *handle) {
             case 'm':
                 type = TIMER;
                 break;
-            case 'k':
-                type = KEY_VAL;
+            case 'k': // Formerly K_V
+            case 'G':
+                type = GAUGE_DIRECT;
                 break;
             case 'g':
                 type = GAUGE;

--- a/src/gauge_direct.c
+++ b/src/gauge_direct.c
@@ -1,0 +1,17 @@
+#include <math.h>
+#include "gauge_direct.h"
+
+
+int init_gauge_direct(gauge_direct_t *gauge) {
+    gauge->value = 0;
+    return 0;
+}
+
+int gauge_direct_add_sample(gauge_direct_t *gauge, double sample) {
+    gauge->value = sample;
+    return 0;
+}
+
+double gauge_direct_value(gauge_direct_t *gauge) {
+    return gauge->value;
+}

--- a/src/gauge_direct.h
+++ b/src/gauge_direct.h
@@ -1,0 +1,33 @@
+#ifndef GAUGE_DIRECT_H
+#define GAUGE_DIRECT_H
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef struct {
+    double value;       // redundant if count == 1, keeping it to reduce footprint of changes
+} gauge_direct_t;
+
+
+/**
+ * Initializes the gauge_direct struct
+ * @arg gauge The gauge struct to initialize
+ * @return 0 on success.
+ */
+int init_gauge_direct(gauge_direct_t *gauge);
+
+/**
+ * Adds a new sample to the struct
+ * @arg gauge The gauge to add to
+ * @arg sample The new sample value
+ * @return 0 on success.
+ */
+int gauge_direct_add_sample(gauge_direct_t *gauge, double sample);
+
+/**
+ * Returns the gauge value
+ * @arg gauge  the gauge to query
+ * @return The gauge value
+ */
+double gauge_direct_value(gauge_direct_t *gauge);
+
+#endif

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -6,14 +6,9 @@
 #include "counter.h"
 #include "timer.h"
 #include "gauge.h"
+#include "gauge_direct.h"
 #include "hashmap.h"
 #include "set.h"
-
-typedef struct key_val {
-    char *name;
-    double val;
-    struct key_val *next;
-} key_val;
 
 typedef struct {
     timer tm;
@@ -24,15 +19,15 @@ typedef struct {
 } timer_hist;
 
 typedef struct {
-    hashmap *counters;  // Hashmap of name -> counter structs
-    hashmap *timers;    // Map of name -> timer_hist structs
-    hashmap *sets;      // Map of name -> set_t structs
-    hashmap *gauges;    // Map of name -> guage struct
-    key_val *kv_vals;   // Linked list of key_val structs
-    double timer_eps;   // The error for timers
-    double *quantiles;  // Array of quantiles
-    uint32_t num_quants; // Size of quantiles array
-    radix_tree *histograms; // Radix tree with histogram configs
+    hashmap *counters;           // Hashmap of name -> counter structs
+    hashmap *timers;             // Map of name -> timer_hist structs
+    hashmap *sets;               // Map of name -> set_t structs
+    hashmap *gauges;             // Map of name -> gauge struct
+    hashmap *gauges_direct;      // Map of name -> gauge_direct struct
+    double timer_eps;            // The error for timers
+    double *quantiles;           // Array of quantiles
+    uint32_t num_quants;         // Size of quantiles array
+    radix_tree *histograms;      // Radix tree with histogram configs
     unsigned char set_precision; // The precision for sets
 } metrics;
 

--- a/src/sink_http.c
+++ b/src/sink_http.c
@@ -153,9 +153,14 @@ static int add_metrics(void* data,
     strcpy(full_name, prefix);
     strcat(full_name, name);
     switch (type) {
-    case KEY_VAL:
-        json_object_set_new(obj, full_name, json_real(*(double*)value));
+    case GAUGE_DIRECT:
+    {
+        double gv = gauge_value(value);
+        if (check_elide(info, full_name, gv) == 1)
+            break;
+        json_object_set_new(obj, full_name, json_real(gauge_value(value)));
         break;
+    }
     case GAUGE:
     {
         const int suffix_space = 8;

--- a/src/sink_stream.c
+++ b/src/sink_stream.c
@@ -22,8 +22,8 @@ static int stream_formatter(FILE *pipe, void *data, metric_type type, char *name
     int i;
     char *prefix = ct->global_config->prefixes_final[type];
     switch (type) {
-        case KEY_VAL:
-            STREAM("%s%s|%f|%lld\n", prefix, name, *(double*)value);
+        case GAUGE_DIRECT:
+            STREAM("%s%s|%f|%lld\n", prefix, name, gauge_direct_value(value));
             break;
 
         case GAUGE:

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -444,10 +444,10 @@ END_TEST
 
 START_TEST(test_sane_prefixes)
 {
-    int fh = open("/tmp/sane_prefixes", O_CREAT|O_RDWR, 0777);
+    int fh = open("/tmp/sane_prefixes_d", O_CREAT|O_RDWR, 0777);
     char *buf = "[statsite]\n\
 use_type_prefix = true\n\
-kv_prefix = keyVALUE.1-2_3\n\
+gaugesdirect_prefix = keyVALUE.1-2_3\n\
 gauges_prefix =\n\
 counts_prefix=foo.counts.bar.\n\
 ";
@@ -457,14 +457,15 @@ counts_prefix=foo.counts.bar.\n\
 
     // Should get the config
     statsite_config config;
-    int res = config_from_filename("/tmp/sane_prefixes", &config);
+    int res = config_from_filename("/tmp/sane_prefixes_d", &config);
     fail_unless(res == 0);
     // And prepare prefixes
     res = prepare_prefixes(&config);
     fail_unless(res == 0);
 
     // Values from config
-    fail_unless(strcmp(config.prefixes_final[KEY_VAL], "keyVALUE.1-2_3") == 0);
+    printf("---- %s\n", config.prefixes_final[GAUGE_DIRECT]);
+    fail_unless(strcmp(config.prefixes_final[GAUGE_DIRECT], "keyVALUE.1-2_3") == 0);
     fail_unless(strcmp(config.prefixes_final[GAUGE], "") == 0);
     fail_unless(strcmp(config.prefixes_final[COUNTER], "foo.counts.bar.") == 0);
 
@@ -472,13 +473,13 @@ counts_prefix=foo.counts.bar.\n\
     fail_unless(strcmp(config.prefixes_final[TIMER], "timers.") == 0);
     fail_unless(strcmp(config.prefixes_final[SET], "sets.") == 0);
 
-    unlink("/tmp/sane_prefixes");
+    unlink("/tmp/sane_prefixes_d");
 
     fh = open("/tmp/sane_prefixes", O_CREAT|O_RDWR, 0777);
 
     buf = "[statsite]\n\
 use_type_prefix = 0\n\
-kv_prefix = keyVALUE.1-2_3\n\
+gaugesdirect_prefix = keyVALUE.1-2_3\n\
 gauges_prefix =\n\
 counts_prefix=foo.sets.bar";
     write(fh, buf, strlen(buf));
@@ -494,7 +495,7 @@ counts_prefix=foo.sets.bar";
     fail_unless(res == 0);
 
     // Values from config
-    fail_unless(strcmp(config.prefixes_final[KEY_VAL], "") == 0);
+    fail_unless(strcmp(config.prefixes_final[GAUGE_DIRECT], "") == 0);
     fail_unless(strcmp(config.prefixes_final[GAUGE], "") == 0);
     fail_unless(strcmp(config.prefixes_final[COUNTER], "") == 0);
 
@@ -509,7 +510,7 @@ counts_prefix=foo.sets.bar";
     buf = "[statsite]\n\
 use_type_prefix = 0\n\
 global_prefix = statsite.\n\
-kv_prefix = keyVALUE.1-2_3\n\
+gaugesdirect_prefix = keyVALUE.1-2_3\n\
 gauges_prefix =\n\
 counts_prefix=foo.sets.bar";
     write(fh, buf, strlen(buf));
@@ -525,7 +526,7 @@ counts_prefix=foo.sets.bar";
     fail_unless(res == 0);
 
     // Values from config
-    fail_unless(strcmp(config.prefixes_final[KEY_VAL], "statsite.") == 0);
+    fail_unless(strcmp(config.prefixes_final[GAUGE_DIRECT], "statsite.") == 0);
     fail_unless(strcmp(config.prefixes_final[GAUGE], "statsite.") == 0);
     fail_unless(strcmp(config.prefixes_final[COUNTER], "statsite.") == 0);
 
@@ -554,7 +555,6 @@ input_counter = foobar\n\
 pid_file = /tmp/statsite.pid\n\
 global_prefix = statsd.\n\
 use_type_prefix = 1\n\
-kv_prefix = keyvalue.\n\
 gauges_prefix =\n\
 sets_prefix=foo.sets.bar.";
     write(fh, buf, strlen(buf));
@@ -582,7 +582,7 @@ sets_prefix=foo.sets.bar.";
     fail_unless(strcmp(config.input_counter, "foobar") == 0);
 
     // Values from config
-    fail_unless(strcmp(config.prefixes_final[KEY_VAL], "statsd.keyvalue.") == 0);
+    fail_unless(strcmp(config.prefixes_final[GAUGE_DIRECT], "statsd.gauges.") == 0);
     fail_unless(strcmp(config.prefixes_final[GAUGE], "statsd.") == 0);
     fail_unless(strcmp(config.prefixes_final[SET], "statsd.foo.sets.bar.") == 0);
 

--- a/tests/test_metrics.c
+++ b/tests/test_metrics.c
@@ -50,7 +50,7 @@ START_TEST(test_metrics_empty_iter)
 END_TEST
 
 static int iter_test_cb(void *data, metric_type type, char *key, void *val) {
-    if (type == KEY_VAL && strcmp(key, "test") == 0) {
+    if (type == GAUGE_DIRECT && strcmp(key, "test") == 0) {
         double *v = val;
         if (*v == 100) {
             int *okay = data;
@@ -67,7 +67,7 @@ START_TEST(test_metrics_add_iter)
     fail_unless(res == 0);
 
     int okay = 0;
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE_DIRECT, "test", 100, 1.0) == 0);
     fail_unless(metrics_iter(&m, (void*)&okay, iter_test_cb) == 0);
     fail_unless(okay == 1);
 
@@ -79,10 +79,10 @@ END_TEST
 static int iter_test_all_cb(void *data, metric_type type, char *key, void *val) {
     int *o = data;
     switch (type) {
-        case KEY_VAL:
-            if (strcmp(key, "test") == 0 && *(double*)val == 100)
+        case GAUGE_DIRECT:
+            if (strcmp(key, "test") == 0 && gauge_direct_value(val) == 100)
                 *o = *o | 1;
-            if (strcmp(key, "test2") == 0 && *(double*)val == 42)
+            if (strcmp(key, "test2") == 0 && gauge_direct_value(val) == 42)
                 *o = *o | 1 << 1;
             break;
         case COUNTER:
@@ -117,8 +117,8 @@ START_TEST(test_metrics_add_all_iter)
     int res = init_metrics_defaults(&m);
     fail_unless(res == 0);
 
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test2", 42, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE_DIRECT, "test", 100, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE_DIRECT, "test2", 42, 1.0) == 0);
 
     fail_unless(metrics_add_sample(&m, GAUGE, "g1", 1, 1.0) == 0);
     fail_unless(metrics_add_sample(&m, GAUGE, "g1", 200, 1.0) == 0);

--- a/tests/test_streaming.c
+++ b/tests/test_streaming.c
@@ -43,8 +43,8 @@ static int some_cb(FILE *pipe, void *data, metric_type type, char *name, void *v
 
     // Try to write
     switch (type) {
-        case KEY_VAL:
-            if (fprintf(pipe, "kv.%s.%f\n", name, *(double*)value) < 0)
+        case GAUGE_DIRECT:
+            if (fprintf(pipe, "gauges.%s.%f\n", name, gauge_direct_value(value)) < 0)
                 return 1;
             break;
 
@@ -71,8 +71,8 @@ START_TEST(test_stream_some)
     fail_unless(res == 0);
 
     // Add some metrics
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test2", 42, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE_DIRECT, "test", 100, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE_DIRECT, "test2", 42, 1.0) == 0);
     fail_unless(metrics_add_sample(&m, COUNTER, "foo", 4, 1.0) == 0);
     fail_unless(metrics_add_sample(&m, COUNTER, "foo", 6, 1.0) == 0);
     fail_unless(metrics_add_sample(&m, COUNTER, "bar", 10, 1.0) == 0);
@@ -90,11 +90,11 @@ START_TEST(test_stream_some)
     ssize_t read = fread(&buf, 1, 256, f);
     buf[read] = 0;
 
-    char *check = "kv.test2.42.000000\n\
-kv.test.100.000000\n\
-counts.foo.10.000000\n\
+    char *check = "counts.foo.10.000000\n\
 counts.bar.30.000000\n\
-timers.baz.11.000000\n";
+timers.baz.11.000000\n\
+gauges.test.100.000000\n\
+gauges.test2.42.000000\n";
     fail_unless(strcmp(check, (char*)&buf) == 0);
 
     res = destroy_metrics(&m);
@@ -111,8 +111,8 @@ START_TEST(test_stream_bad_cmd)
     fail_unless(res == 0);
 
     // Add some metrics
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test2", 42, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE_DIRECT, "test", 100, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE_DIRECT, "test2", 42, 1.0) == 0);
     fail_unless(metrics_add_sample(&m, COUNTER, "foo", 4, 1.0) == 0);
     fail_unless(metrics_add_sample(&m, COUNTER, "foo", 6, 1.0) == 0);
     fail_unless(metrics_add_sample(&m, COUNTER, "bar", 10, 1.0) == 0);
@@ -136,8 +136,8 @@ START_TEST(test_stream_sigpipe)
     fail_unless(res == 0);
 
     // Add some metrics
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test2", 42, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE_DIRECT, "test", 100, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE_DIRECT, "test2", 42, 1.0) == 0);
     fail_unless(metrics_add_sample(&m, COUNTER, "foo", 4, 1.0) == 0);
     fail_unless(metrics_add_sample(&m, COUNTER, "foo", 6, 1.0) == 0);
     fail_unless(metrics_add_sample(&m, COUNTER, "bar", 10, 1.0) == 0);


### PR DESCRIPTION
Replaces the previously scary and mostly useless KV type with a
direct_gauge type (type 'G' or 'k') which only reports the last set
value in all cases.