### PR TITLE
Support compressing payloads in the http sink

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -68,7 +68,7 @@ objs = env_statsite_with_err.Object('src/hashmap', 'src/hashmap.c')             
         env_statsite_libev.Object('src/networking', 'src/networking.c')              + \
         env_statsite_libev.Object('src/conn_handler', 'src/conn_handler.c')
 
-statsite_libs = ["m", "pthread", murmur, inih, "jansson", curl_lib]
+statsite_libs = ["m", "pthread", murmur, inih, "jansson", curl_lib, "zstd"]
 if platform.system() == 'Linux':
    statsite_libs.append("rt")
 


### PR DESCRIPTION
This adds a required whole-body compression after form-encoding the
body to the matroska doll hellscape of the statsite http format.